### PR TITLE
Member/feat/34

### DIFF
--- a/src/main/java/com/eum/global/config/WebConfig.java
+++ b/src/main/java/com/eum/global/config/WebConfig.java
@@ -1,11 +1,17 @@
 package com.eum.global.config;
 
+import com.eum.member.auth.JwtAuthInterceptor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+    private final JwtAuthInterceptor jwtAuthInterceptor;
+
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
@@ -13,5 +19,11 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedMethods("GET", "POST", "PUT", "DELETE")
                 .allowedHeaders("*")
                 .allowCredentials(true);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(jwtAuthInterceptor)
+                .addPathPatterns(""); // 필요한 경로 지정
     }
 }

--- a/src/main/java/com/eum/member/auth/JwtAuthInterceptor.java
+++ b/src/main/java/com/eum/member/auth/JwtAuthInterceptor.java
@@ -1,0 +1,41 @@
+package com.eum.member.auth;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthInterceptor implements HandlerInterceptor {
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
+        String header = request.getHeader("Authorization");
+
+        if (header != null && header.startsWith("Bearer ")) {
+            String token = header.replace("Bearer ", "");
+
+            if (jwtUtil.validateJwtToken(token)) {
+                Claims claims = jwtUtil.extractClaims(token);
+                String publicId = claims.getSubject();
+
+                // 요청 속성에 저장
+                request.setAttribute("publicId", publicId);
+                return true;
+            }
+        }
+
+        // 토큰이 없거나 유효하지 않은 경우 요청 차단
+        // 401 Unauthorized
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+        response.getWriter().write("{\"message\": \"Invalid or missing JWT token\"}");
+        return false;
+    }
+}

--- a/src/main/java/com/eum/member/controller/LoginController.java
+++ b/src/main/java/com/eum/member/controller/LoginController.java
@@ -3,6 +3,7 @@ package com.eum.member.controller;
 import com.eum.member.model.dto.request.LoginRequestDto;
 import com.eum.member.model.dto.response.LoginResponseDto;
 import com.eum.member.service.KakaoLoginService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
@@ -42,4 +43,6 @@ public class LoginController {
             return ResponseEntity.status(401).body("Invalid or expired token");
         }
     }
+
+
 }

--- a/src/main/java/com/eum/member/model/entity/Member.java
+++ b/src/main/java/com/eum/member/model/entity/Member.java
@@ -36,6 +36,10 @@ public class Member {
     // 직무
     @Column(nullable = false)
     private String position;
+    // 기술 스택
+    @Column(nullable = false)
+    private String techStack;
+    // 경력
     @Column(nullable = false)
     private String career;
     @Column
@@ -51,6 +55,7 @@ public class Member {
             String nickname,
             String profileImageUrl,
             String position,
+            String techStack,
             String career,
             String shortDescription
     ) {
@@ -60,6 +65,7 @@ public class Member {
         member.nickname = nickname;
         member.profileImageUrl = profileImageUrl;
         member.position = position;
+        member.techStack = techStack;
         member.career = career;
         member.shortDescription = shortDescription;
 

--- a/src/main/java/com/eum/member/model/entity/MemberPosition.java
+++ b/src/main/java/com/eum/member/model/entity/MemberPosition.java
@@ -1,0 +1,32 @@
+package com.eum.member.model.entity;
+
+import com.eum.global.model.entity.Position;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "Member_Position")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberPosition {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne
+    @JoinColumn(name = "position_id", nullable = false)
+    private Position position;
+
+    public static MemberPosition of(Member member, Position position) {
+        MemberPosition memberPosition = new MemberPosition();
+        memberPosition.member = member;
+        memberPosition.position = position;
+        return memberPosition;
+    }
+}

--- a/src/main/java/com/eum/member/model/entity/MemberTechStack.java
+++ b/src/main/java/com/eum/member/model/entity/MemberTechStack.java
@@ -1,0 +1,32 @@
+package com.eum.member.model.entity;
+
+import com.eum.global.model.entity.TechStack;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "Member_TechStack")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberTechStack {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne
+    @JoinColumn(name = "techStack_id", nullable = false)
+    private TechStack techStack;
+
+    public static MemberTechStack of(Member member, TechStack techStack) {
+        MemberTechStack memberTechStack = new MemberTechStack();
+        memberTechStack.member = member;
+        memberTechStack.techStack = techStack;
+        return memberTechStack;
+    }
+}

--- a/src/main/java/com/eum/member/model/repository/MemberPositionRepository.java
+++ b/src/main/java/com/eum/member/model/repository/MemberPositionRepository.java
@@ -1,0 +1,9 @@
+package com.eum.member.model.repository;
+
+import com.eum.member.model.entity.MemberPosition;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberPositionRepository extends JpaRepository<MemberPosition, Long> {
+}

--- a/src/main/java/com/eum/member/model/repository/MemberTechStackRepository.java
+++ b/src/main/java/com/eum/member/model/repository/MemberTechStackRepository.java
@@ -1,0 +1,8 @@
+package com.eum.member.model.repository;
+
+import com.eum.member.model.entity.MemberTechStack;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberTechStackRepository extends JpaRepository<MemberTechStack, Long> {}

--- a/src/main/java/com/eum/member/service/impl/KakaoLoginServiceImpl.java
+++ b/src/main/java/com/eum/member/service/impl/KakaoLoginServiceImpl.java
@@ -61,6 +61,7 @@ public class KakaoLoginServiceImpl implements KakaoLoginService {
                             "UNDEFINED",
                             "UNDEFINED",
                             "UNDEFINED",
+                            "UNDEFINED",
                             null
                     );
                     //publicId 세팅


### PR DESCRIPTION
## 관련 이슈

> #34 

## 작업 내용
프로필 설정을 위한 중간 테이블용 Entity 및 Repository 생성

JwtAuthInterceptor 구현 -> 원하는 api에서 Jwt 검증 및 publicId 추출 가능

- 사용 방법
     1.  WebConfig 내 addInterceptors에서 
         addPathPatterns("") 안에 원하는 경로 지정 - Jwt 검사할 경로
         excludePathPatterns("") 안에 제외할 경로 지정 - Jwt 검사 안 할 경로
     2. Controller에서 지정한 api에서 HttpServletRequest request를 parameter로 받아서 
         request.getAttribute("publicId")로 사용 가능

- 실제 예시
     1. registry.addInterceptor(jwtAuthInterceptor)
                .addPathPatterns("/api/v1/protected-endpoint");
     2.  
     @GetMapping("/api/v1/protected-endpoint")
     public ResponseEntity<String> testEndpoint(HttpServletRequest request) {
         String publicId = (String) request.getAttribute("publicId");
         return ResponseEntity.ok("Authenticated user: " + publicId);
     }

## ETC
> 참고할만한 링크 또는 메모

