### PR TITLE
[게시글] 게시글 조회 필터링에 status 필터링 기능 추가 및 Post,PostMember 관련 리펙토링

### DIFF
--- a/src/main/java/com/eum/post/controller/PostController.java
+++ b/src/main/java/com/eum/post/controller/PostController.java
@@ -75,18 +75,13 @@ public class PostController {
     @PostMapping
     public ResponseEntity<PostResponse> createPost(
             @RequestBody PostRequest request,
-            //@RequestHeader("Authorization") UUID userId
             HttpServletRequest httpRequest
         ) {
 
         // JWT 인터셉터가 설정한 publicId 가져오기
         UUID publicId = (UUID) httpRequest.getAttribute("publicId");
-        if (publicId == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        }
 
         PostResponse response = postService.create(request, publicId);
-        //PostResponse response = postService.create(request, userId);
         // 201 Created 상태코드와 함께 응답
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
@@ -101,17 +96,12 @@ public class PostController {
     @DeleteMapping("/{postId}")
     public ResponseEntity<Void> deletePost(
             @PathVariable Long postId,
-            //@RequestHeader("Authorization") UUID userId
             HttpServletRequest httpRequest
     ) {
 
         UUID publicId = (UUID) httpRequest.getAttribute("publicId");
-        if (publicId == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        }
 
         postService.deletePost(postId, publicId);
-        //postService.deletePost(postId, userId);
         return ResponseEntity.noContent().build(); // 204 No Content 상태코드 반환
     }
 
@@ -127,17 +117,12 @@ public class PostController {
     public ResponseEntity<PostResponse> updatePost(
             @PathVariable Long postId,
             @RequestBody PostRequest request,
-            //@RequestHeader("Authorization") UUID userId
             HttpServletRequest httpRequest
     ) {
 
         UUID publicId = (UUID) httpRequest.getAttribute("publicId");
-        if (publicId == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        }
 
         PostResponse response = postService.update(postId, request, publicId);
-        //PostResponse response = postService.update(postId, request, userId);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/eum/post/controller/PostController.java
+++ b/src/main/java/com/eum/post/controller/PostController.java
@@ -6,6 +6,7 @@ import com.eum.post.model.dto.response.PostResponse;
 import com.eum.post.model.entity.enumerated.CultureFit;
 import com.eum.post.model.entity.enumerated.ProgressMethod;
 import com.eum.post.model.entity.enumerated.RecruitType;
+import com.eum.post.model.entity.enumerated.Status;
 import com.eum.post.service.PostService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -52,6 +53,7 @@ public class PostController {
         RecruitType recruitTypeEnum = RecruitType.fromString(filter.recruitType());
         ProgressMethod progressMethodEnum = ProgressMethod.fromString(filter.progressMethod());
         CultureFit cultureFitEnum = CultureFit.fromString(filter.cultureFit());
+        Status statusEnum = Status.fromString(filter.status());
 
         // 서비스 호출
         Page<PostResponse> responses = postService.findPostsWithFilters(
@@ -59,6 +61,7 @@ public class PostController {
                 recruitTypeEnum,
                 progressMethodEnum,
                 cultureFitEnum,
+                statusEnum,
                 filter.positionId(),
                 filter.techStackIds(),
                 pageable);

--- a/src/main/java/com/eum/post/controller/PostController.java
+++ b/src/main/java/com/eum/post/controller/PostController.java
@@ -1,5 +1,6 @@
 package com.eum.post.controller;
 
+import com.eum.post.model.dto.PostDto;
 import com.eum.post.model.dto.request.PostFilterRequest;
 import com.eum.post.model.dto.request.GithubLinkRequest;
 import com.eum.post.model.dto.request.PostRequest;
@@ -36,8 +37,8 @@ public class PostController {
      */
     @GetMapping("/{postId}")
     public ResponseEntity<PostResponse> getPost(@PathVariable Long postId) {
-        PostResponse response = postService.findByPostId(postId);
-        return ResponseEntity.ok(response);
+        PostDto dto = postService.findByPostId(postId);
+        return ResponseEntity.ok(PostResponse.from(dto));
     }
 
     /**
@@ -56,17 +57,19 @@ public class PostController {
         CultureFit cultureFitEnum = CultureFit.fromString(filter.cultureFit());
         Status statusEnum = Status.fromString(filter.status());
 
-        // 서비스 호출
-        Page<PostResponse> responses = postService.findPostsWithFilters(
-                filter.keyword(),
-                recruitTypeEnum,
-                progressMethodEnum,
-                cultureFitEnum,
-                statusEnum,
-                filter.positionId(),
-                filter.techStackIds(),
-                pageable);
-        return ResponseEntity.ok(responses);
+        // 서비스 호출 및 응답 변환
+        return ResponseEntity.ok(
+                postService.findPostsWithFilters(
+                                filter.keyword(),
+                                recruitTypeEnum,
+                                progressMethodEnum,
+                                cultureFitEnum,
+                                statusEnum,
+                                filter.positionId(),
+                                filter.techStackIds(),
+                                pageable)
+                        .map(PostResponse::from)
+        );
     }
 
     /**
@@ -82,9 +85,11 @@ public class PostController {
         // JWT 인터셉터가 설정한 publicId 가져오기
         UUID publicId = (UUID) httpRequest.getAttribute("publicId");
 
-        PostResponse response = postService.create(request, publicId);
-        // 201 Created 상태코드와 함께 응답
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        return ResponseEntity.status(HttpStatus.CREATED).body(
+                PostResponse.from(
+                        postService.create(request, publicId)
+                )
+        );
     }
 
     /**
@@ -123,8 +128,11 @@ public class PostController {
 
         UUID publicId = (UUID) httpRequest.getAttribute("publicId");
 
-        PostResponse response = postService.update(postId, request, publicId);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(
+                PostResponse.from(
+                        postService.update(postId, request, publicId)
+                )
+        );
     }
 
     @PatchMapping("/{postId}/complete")
@@ -137,6 +145,11 @@ public class PostController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
 
-        return ResponseEntity.ok(postService.completePost(postId, publicId, request.githubLink()));
+        //return ResponseEntity.ok(postService.completePost(postId, publicId, request.githubLink()));
+        return ResponseEntity.ok(
+                PostResponse.from(
+                        postService.completePost(postId, publicId, request.githubLink())
+                )
+        );
     }
 }

--- a/src/main/java/com/eum/post/controller/PostMemberController.java
+++ b/src/main/java/com/eum/post/controller/PostMemberController.java
@@ -2,6 +2,7 @@ package com.eum.post.controller;
 
 import com.eum.member.model.entity.Member;
 import com.eum.member.model.repository.MemberRepository;
+import com.eum.post.model.dto.PostMemberDto;
 import com.eum.post.model.dto.request.PostMemberRequest;
 import com.eum.post.model.dto.response.PostMemberResponse;
 import com.eum.post.service.PostMemberService;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/v1/posts")
@@ -44,14 +46,12 @@ public class PostMemberController {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
-        // 내부 ID 사용하여 서비스 메서드 호출
-        List<PostMemberResponse> responses = postMemberService.updateMembers(
-                postId,
-                request.nicknames(),
-                member.getId()  // 내부 ID 전달
+        return ResponseEntity.ok(
+                postMemberService.updateMembers(postId, request.nicknames(), member.getId())
+                        .stream()
+                        .map(PostMemberResponse::from)
+                        .collect(Collectors.toList())
         );
-
-        return ResponseEntity.ok(responses);
     }
 
     /**
@@ -59,7 +59,11 @@ public class PostMemberController {
      */
     @GetMapping("/{postId}/members")
     public ResponseEntity<List<PostMemberResponse>> getMembers(@PathVariable Long postId) {
-        List<PostMemberResponse> responses = postMemberService.getPostMembers(postId);
-        return ResponseEntity.ok(responses);
+        return ResponseEntity.ok(
+                postMemberService.getPostMembers(postId)
+                        .stream()
+                        .map(PostMemberResponse::from)
+                        .collect(Collectors.toList())
+        );
     }
 }

--- a/src/main/java/com/eum/post/controller/PostMemberController.java
+++ b/src/main/java/com/eum/post/controller/PostMemberController.java
@@ -30,14 +30,10 @@ public class PostMemberController {
     public ResponseEntity<List<PostMemberResponse>> updateMembers(
         @PathVariable Long postId,
         @RequestBody PostMemberRequest request,
-        //@RequestHeader("Authorization") UUID publicId
         HttpServletRequest httpRequest
     )
     {
         UUID publicId = (UUID) httpRequest.getAttribute("publicId");
-        if (publicId == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        }
 
         // publicId로 Member 조회하여 내부 ID 얻기
         Member member = memberRepository.findByPublicId(publicId)

--- a/src/main/java/com/eum/post/controller/PostMemberController.java
+++ b/src/main/java/com/eum/post/controller/PostMemberController.java
@@ -37,17 +37,8 @@ public class PostMemberController {
     {
         UUID publicId = (UUID) httpRequest.getAttribute("publicId");
 
-        // publicId로 Member 조회하여 내부 ID 얻기
-        Member member = memberRepository.findByPublicId(publicId)
-                .orElseThrow(() -> new EntityNotFoundException("멤버를 찾을 수 없습니다."));
-
-        // 본인이 게시글 모집자인지 확인 (권한 검사)
-        if (!postMemberService.isOwner(postId, member.getId())) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        }
-
         return ResponseEntity.ok(
-                postMemberService.updateMembers(postId, request.nicknames(), member.getId())
+                postMemberService.updateMembers(postId, request.nicknames(), publicId)
                         .stream()
                         .map(PostMemberResponse::from)
                         .collect(Collectors.toList())

--- a/src/main/java/com/eum/post/model/dto/PositionDto.java
+++ b/src/main/java/com/eum/post/model/dto/PositionDto.java
@@ -1,10 +1,6 @@
 package com.eum.post.model.dto;
 
 import com.eum.global.model.entity.Position;
-import com.eum.post.model.dto.response.PositionResponse;
-import com.eum.post.model.dto.response.TechStackResponse;
-
-import java.util.List;
 
 public record PositionDto(
         Long id,

--- a/src/main/java/com/eum/post/model/dto/request/PostFilterRequest.java
+++ b/src/main/java/com/eum/post/model/dto/request/PostFilterRequest.java
@@ -7,6 +7,7 @@ public record PostFilterRequest(
         String recruitType,
         String progressMethod,
         String cultureFit,
+        String status,
         Long positionId,
         List<Long> techStackIds
 ) {}

--- a/src/main/java/com/eum/post/model/dto/request/PostRequest.java
+++ b/src/main/java/com/eum/post/model/dto/request/PostRequest.java
@@ -17,7 +17,6 @@ public record PostRequest(
         LocalDate deadline,
         LinkType linkType,
         String link,
-        //CultureFit cultureFit,
         List<Long> techStackIds,
         List<Long> positionIds
 ) {
@@ -37,7 +36,6 @@ public record PostRequest(
                 deadline,
                 linkType,
                 link
-                //cultureFit
         );
     }
 }

--- a/src/main/java/com/eum/post/model/dto/response/PositionResponse.java
+++ b/src/main/java/com/eum/post/model/dto/response/PositionResponse.java
@@ -1,7 +1,6 @@
 package com.eum.post.model.dto.response;
 
 import com.eum.post.model.dto.PositionDto;
-import com.eum.post.model.dto.TechStackDto;
 
 public record PositionResponse(
         Long id,

--- a/src/main/java/com/eum/post/model/dto/response/PostPositionResponse.java
+++ b/src/main/java/com/eum/post/model/dto/response/PostPositionResponse.java
@@ -1,7 +1,6 @@
 package com.eum.post.model.dto.response;
 
 import com.eum.post.model.dto.PostPositionDto;
-import com.eum.post.model.entity.PostPosition;
 
 public record PostPositionResponse(
         Long id,

--- a/src/main/java/com/eum/post/model/entity/Post.java
+++ b/src/main/java/com/eum/post/model/entity/Post.java
@@ -121,7 +121,6 @@ public class Post {
         this.deadline = dto.deadline();
         this.linkType = dto.linkType();
         this.link = dto.link();
-        //this.cultureFit = dto.cultureFit();
         // createdAt은 수정하지 않음 (JPA에서 @UpdateTimestamp로 updatedAt은 자동 업데이트)
     }
 

--- a/src/main/java/com/eum/post/model/entity/enumerated/Status.java
+++ b/src/main/java/com/eum/post/model/entity/enumerated/Status.java
@@ -5,4 +5,13 @@ public enum Status {
     CLOSED, // 게시글 마감
     ONGOING, // 진행중
     COMPLETED; // 완료
+
+    public static Status fromString(String value) {
+        if (value == null || value.isEmpty()) return RECRUITING;
+        try {
+            return Status.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return RECRUITING;
+        }
+    }
 }

--- a/src/main/java/com/eum/post/model/repository/PostSpecification.java
+++ b/src/main/java/com/eum/post/model/repository/PostSpecification.java
@@ -6,6 +6,7 @@ import com.eum.post.model.entity.PostTechStack;
 import com.eum.post.model.entity.enumerated.CultureFit;
 import com.eum.post.model.entity.enumerated.ProgressMethod;
 import com.eum.post.model.entity.enumerated.RecruitType;
+import com.eum.post.model.entity.enumerated.Status;
 import jakarta.persistence.criteria.*;
 import org.springframework.data.jpa.domain.Specification;
 
@@ -124,6 +125,16 @@ public class PostSpecification {
 
             // AND 조건 (모든 기술 스택을 포함하는 게시글)
             return criteriaBuilder.and(predicates.toArray(new Predicate[0]));
+        };
+    }
+
+    // Status로 필터링
+    public static Specification<Post> hasStatus(Status status) {
+        return (root, query, criteriaBuilder) -> {
+            if (status == null) {
+                return null;
+            }
+            return criteriaBuilder.equal(root.get("status"), status);
         };
     }
 }

--- a/src/main/java/com/eum/post/model/repository/PostTechStackRepository.java
+++ b/src/main/java/com/eum/post/model/repository/PostTechStackRepository.java
@@ -1,6 +1,5 @@
 package com.eum.post.model.repository;
 
-import com.eum.post.model.entity.PostPosition;
 import com.eum.post.model.entity.PostTechStack;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/com/eum/post/service/PostMemberService.java
+++ b/src/main/java/com/eum/post/service/PostMemberService.java
@@ -1,5 +1,6 @@
 package com.eum.post.service;
 
+import com.eum.post.model.dto.PostMemberDto;
 import com.eum.post.model.dto.response.PostMemberResponse;
 
 import java.util.List;
@@ -14,7 +15,8 @@ public interface PostMemberService {
      * @param ownerId 소유자(모집자) ID
      * @return 업데이트된 멤버 목록
      */
-    List<PostMemberResponse> updateMembers(Long postId, List<String> nicknames, Long ownerId);
+    //List<PostMemberResponse> updateMembers(Long postId, List<String> nicknames, Long ownerId);
+    List<PostMemberDto> updateMembers(Long postId, List<String> nicknames, Long ownerId);
 
     /**
      * 게시글 멤버 목록을 조회합니다.
@@ -22,7 +24,8 @@ public interface PostMemberService {
      * @param postId 게시글 ID
      * @return 멤버 목록
      */
-    List<PostMemberResponse> getPostMembers(Long postId);
+    //List<PostMemberResponse> getPostMembers(Long postId);
+    List<PostMemberDto> getPostMembers(Long postId);
 
     /**
      * 특정 사용자가 게시글의 소유자(모집자)인지 확인합니다.

--- a/src/main/java/com/eum/post/service/PostMemberService.java
+++ b/src/main/java/com/eum/post/service/PostMemberService.java
@@ -1,9 +1,9 @@
 package com.eum.post.service;
 
 import com.eum.post.model.dto.PostMemberDto;
-import com.eum.post.model.dto.response.PostMemberResponse;
 
 import java.util.List;
+import java.util.UUID;
 
 public interface PostMemberService {
     /**
@@ -15,8 +15,8 @@ public interface PostMemberService {
      * @param ownerId 소유자(모집자) ID
      * @return 업데이트된 멤버 목록
      */
-    //List<PostMemberResponse> updateMembers(Long postId, List<String> nicknames, Long ownerId);
-    List<PostMemberDto> updateMembers(Long postId, List<String> nicknames, Long ownerId);
+    //List<PostMemberDto> updateMembers(Long postId, List<String> nicknames, Long ownerId);
+    List<PostMemberDto> updateMembers(Long postId, List<String> nicknames, UUID ownerId);
 
     /**
      * 게시글 멤버 목록을 조회합니다.
@@ -24,15 +24,16 @@ public interface PostMemberService {
      * @param postId 게시글 ID
      * @return 멤버 목록
      */
-    //List<PostMemberResponse> getPostMembers(Long postId);
     List<PostMemberDto> getPostMembers(Long postId);
 
     /**
      * 특정 사용자가 게시글의 소유자(모집자)인지 확인합니다.
      *
      * @param postId 게시글 ID
-     * @param memberId 확인할 멤버 ID
+     * @param ownerId 확인할 멤버 ID
      * @return 소유자 여부
      */
-    boolean isOwner(Long postId, Long memberId);
+    boolean isOwner(Long postId, Long ownerId);
+
+    boolean isOwnerByPublicId(Long postId, UUID ownerId);
 }

--- a/src/main/java/com/eum/post/service/PostService.java
+++ b/src/main/java/com/eum/post/service/PostService.java
@@ -1,6 +1,5 @@
 package com.eum.post.service;
 
-import com.eum.ai.model.dto.request.CultureFitRequest;
 import com.eum.post.model.dto.request.PostRequest;
 import com.eum.post.model.dto.response.PostResponse;
 import com.eum.post.model.entity.enumerated.CultureFit;
@@ -9,24 +8,18 @@ import com.eum.post.model.entity.enumerated.RecruitType;
 import com.eum.post.model.entity.enumerated.Status;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 
-import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
 public interface PostService {
 
-//    PostResponse create(PostRequest postRequest, Long userId);
     PostResponse create(PostRequest postRequest, UUID publicId);
 
     PostResponse findByPostId(Long postId); // 개별만 조회
 
-    //PostResponse update(Long postId, PostRequest postRequest, Long userId);
     PostResponse update(Long postId, PostRequest postRequest, UUID publicId);
 
-    //void deletePost(Long postId, Long userId);
     void deletePost(Long postId, UUID publicId);
 
     PostResponse completePost(Long postId, Long userId, String githubLink);

--- a/src/main/java/com/eum/post/service/PostService.java
+++ b/src/main/java/com/eum/post/service/PostService.java
@@ -5,6 +5,7 @@ import com.eum.post.model.dto.response.PostResponse;
 import com.eum.post.model.entity.enumerated.CultureFit;
 import com.eum.post.model.entity.enumerated.ProgressMethod;
 import com.eum.post.model.entity.enumerated.RecruitType;
+import com.eum.post.model.entity.enumerated.Status;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 

--- a/src/main/java/com/eum/post/service/PostService.java
+++ b/src/main/java/com/eum/post/service/PostService.java
@@ -37,6 +37,7 @@ public interface PostService {
             RecruitType recruitType,
             ProgressMethod progressMethod,
             CultureFit cultureFit,
+            Status status,
             Long positionId,
             List<Long> techStackIds,
             Pageable pageable

--- a/src/main/java/com/eum/post/service/PostService.java
+++ b/src/main/java/com/eum/post/service/PostService.java
@@ -1,5 +1,6 @@
 package com.eum.post.service;
 
+import com.eum.post.model.dto.PostDto;
 import com.eum.post.model.dto.request.PostRequest;
 import com.eum.post.model.dto.response.PostResponse;
 import com.eum.post.model.entity.enumerated.CultureFit;
@@ -14,18 +15,19 @@ import java.util.UUID;
 
 public interface PostService {
 
-    PostResponse create(PostRequest postRequest, UUID publicId);
+    PostDto create(PostRequest postRequest, UUID publicId);
 
-    PostResponse findByPostId(Long postId); // 개별만 조회
+    PostDto findByPostId(Long postId); // 개별만 조회
 
-    PostResponse update(Long postId, PostRequest postRequest, UUID publicId);
+    PostDto update(Long postId, PostRequest postRequest, UUID publicId);
 
     void deletePost(Long postId, UUID publicId);
 
-    PostResponse completePost(Long postId, UUID publicId, String githubLink) ;
+    //PostResponse completePost(Long postId, UUID publicId, String githubLink) ;
+    PostDto completePost(Long postId, UUID publicId, String githubLink) ;
 
     // 필터링 기능 추가
-    Page<PostResponse> findPostsWithFilters(
+    Page<PostDto> findPostsWithFilters(
             String keyword,
             RecruitType recruitType,
             ProgressMethod progressMethod,

--- a/src/main/java/com/eum/post/service/impl/PostMemberServiceImpl.java
+++ b/src/main/java/com/eum/post/service/impl/PostMemberServiceImpl.java
@@ -30,7 +30,7 @@ public class PostMemberServiceImpl implements PostMemberService {
 
     @Override
     @Transactional
-    public List<PostMemberResponse> updateMembers(
+    public List<PostMemberDto> updateMembers(
             Long postId,
             List<String> nicknames,
             Long ownerId
@@ -54,15 +54,15 @@ public class PostMemberServiceImpl implements PostMemberService {
         // 결과 조회 및 반환
         List<PostMember> resultMembers = postMemberRepository.findAllWithMemberByPostId(postId);
         return resultMembers.stream()
-                .map(member -> PostMemberResponse.from(PostMemberDto.from(member)))
+                .map(PostMemberDto::from)  // 직접 PostMemberDto로 변환
                 .collect(Collectors.toList());
     }
 
     @Override
     @Transactional(readOnly = true)
-    public List<PostMemberResponse> getPostMembers(Long postId) {
+    public List<PostMemberDto> getPostMembers(Long postId) {
         return postMemberRepository.findAllWithMemberByPostId(postId).stream()
-                .map(member -> PostMemberResponse.from(PostMemberDto.from(member)))
+                .map(PostMemberDto::from)  // 직접 PostMemberDto로 변환
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/eum/post/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/eum/post/service/impl/PostServiceImpl.java
@@ -12,7 +12,6 @@ import com.eum.post.model.dto.PositionDto;
 import com.eum.post.model.dto.PostDto;
 import com.eum.post.model.dto.TechStackDto;
 import com.eum.post.model.dto.request.PostRequest;
-import com.eum.post.model.dto.response.PostResponse;
 import com.eum.post.model.dto.response.PostUpdateResponse;
 import com.eum.post.model.entity.Post;
 import com.eum.post.model.entity.PostMember;

--- a/src/main/java/com/eum/post/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/eum/post/service/impl/PostServiceImpl.java
@@ -57,7 +57,7 @@ public class PostServiceImpl implements PostService{
 
     @Override
     @Transactional
-    public PostResponse create(
+    public PostDto create(
             PostRequest postRequest,
             UUID publicId
     ) {
@@ -81,9 +81,7 @@ public class PostServiceImpl implements PostService{
         // position 연결
         List<PositionDto> positionDtos = savePositions(savedPost, postRequest.positionIds());
 
-        // 4. DTO 변환 및 반환
-        PostDto postDto = PostDto.from(savedPost, techStackDtos, positionDtos);
-        return PostResponse.from(postDto);
+        return PostDto.from(post, techStackDtos, positionDtos);
     }
 
     // 기술 스택 저장 메소드
@@ -145,7 +143,7 @@ public class PostServiceImpl implements PostService{
 
     @Override
     @Transactional(readOnly = true)
-    public PostResponse findByPostId(Long postId) {
+    public PostDto findByPostId(Long postId) {
         // 게시글 조회
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
@@ -156,14 +154,12 @@ public class PostServiceImpl implements PostService{
         // 관련 포지션 조회
         List<PositionDto> positionDtos = findPositionsByPostId(post.getId());
 
-        // DTO 변환 및 반환
-        PostDto postDto = PostDto.from(post, techStackDtos, positionDtos);
-        return PostResponse.from(postDto);
+        return PostDto.from(post, techStackDtos, positionDtos);
     }
 
     @Override
     @Transactional
-    public PostResponse update(
+    public PostDto update(
             Long postId,
             PostRequest postRequest,
             UUID publicId
@@ -199,9 +195,7 @@ public class PostServiceImpl implements PostService{
         List<TechStackDto> techStackDtos = saveTechStacks(post, postRequest.techStackIds());
         List<PositionDto> positionDtos = savePositions(post, postRequest.positionIds());
 
-        // DTO 변환 및 반환
-        PostDto postDto = PostDto.from(post, techStackDtos, positionDtos);
-        return PostResponse.from(postDto);
+        return PostDto.from(post, techStackDtos, positionDtos);
     }
 
     @Override
@@ -232,7 +226,7 @@ public class PostServiceImpl implements PostService{
 
     //merge 된 부분
     @Override
-    public PostResponse completePost(Long postId, UUID publicId, String githubLink) {
+    public PostDto completePost(Long postId, UUID publicId, String githubLink) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
 
@@ -250,13 +244,12 @@ public class PostServiceImpl implements PostService{
         List<TechStackDto> techStackDtos = findTechStacksByPostId(postId);
         List<PositionDto> positionDtos = findPositionsByPostId(postId);
 
-        PostDto postDto = PostDto.from(post, techStackDtos, positionDtos);
-        return PostResponse.from(postDto);
+        return PostDto.from(post, techStackDtos, positionDtos);
     }
 
     @Override
     @Transactional(readOnly = true)
-    public Page<PostResponse> findPostsWithFilters(
+    public Page<PostDto> findPostsWithFilters(
             String keyword,
             RecruitType recruitType,
             ProgressMethod progressMethod,
@@ -312,9 +305,7 @@ public class PostServiceImpl implements PostService{
             List<TechStackDto> techStackDtos = findTechStacksByPostId(post.getId());
             List<PositionDto> positionDtos = findPositionsByPostId(post.getId());
 
-            // DTO 변환
-            PostDto postDto = PostDto.from(post, techStackDtos, positionDtos);
-            return PostResponse.from(postDto);
+            return PostDto.from(post, techStackDtos, positionDtos);
         });
     }
 }

--- a/src/main/java/com/eum/post/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/eum/post/service/impl/PostServiceImpl.java
@@ -253,7 +253,16 @@ public class PostServiceImpl implements PostService{
 
     @Override
     @Transactional(readOnly = true)
-    public Page<PostResponse> findPostsWithFilters(String keyword, RecruitType recruitType, ProgressMethod progressMethod, CultureFit cultureFit, Long positionId, List<Long> techStackIds, Pageable pageable) {
+    public Page<PostResponse> findPostsWithFilters(
+            String keyword,
+            RecruitType recruitType,
+            ProgressMethod progressMethod,
+            CultureFit cultureFit,
+            Status status,
+            Long positionId,
+            List<Long> techStackIds,
+            Pageable pageable) {
+
         // 명세 조합
         Specification<Post> spec = Specification.where(null);
 
@@ -276,6 +285,10 @@ public class PostServiceImpl implements PostService{
         if (cultureFit != null) {
             spec = spec.and(PostSpecification.hasCultureFit(cultureFit));
         }
+
+        // 상태에 대한 필터링 - 기본적으로 RECRUITING 상태 적용
+        // status 매개변수가 null이면 Status.fromString 메소드에서 RECRUITING을 반환
+        spec = spec.and(PostSpecification.hasStatus(status));
 
         // 포지션에 대한 필터링
         if (positionId != null) {

--- a/src/test/java/com/eum/post/service/impl/PostServiceImplTest.java
+++ b/src/test/java/com/eum/post/service/impl/PostServiceImplTest.java
@@ -72,7 +72,7 @@ public class PostServiceImplTest {
     private Position testPosition;
     private TechStack testTechStack;
     //private Long testUserId;
-    private UUID testUserId;
+    private UUID testUserId; //UUID로 변경
 
     @BeforeEach
     void setUp() {
@@ -100,12 +100,12 @@ public class PostServiceImplTest {
         // Member 객체 Mock 생성
         Member testMember = mock(Member.class);
         when(testMember.getPublicId()).thenReturn(testUserId);
+
         // 테스트 Post 엔티티 생성
         testPost = testPostRequest.toEntity(testMember);
-        setPostId(testPost, 1L);
 
-//        testPost = testPostRequest.toEntity(testUserId);
-//        setPostId(testPost, 1L);
+        //testPost = testPostRequest.toEntity(testUserId); 기존 코드
+        setPostId(testPost, 1L);
     }
 
     // 유틸리티 메서드
@@ -245,6 +245,7 @@ public class PostServiceImplTest {
     void updateNoPermissionFail() {
         Long postId = 1L;
         //Long differentUserId = 999L;
+        //UUID로 변경
         UUID differentUserId = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");  // 다른 UUID 사용
 
 
@@ -276,6 +277,7 @@ public class PostServiceImplTest {
     void deletePostNoPermissionFail() {
         Long postId = 1L;
         //Long differentUserId = 999L;
+        //UUID로 변경
         UUID differentUserId = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");  // 다른 UUID 사용
 
 

--- a/src/test/java/com/eum/post/service/impl/PostServiceImplTest.java
+++ b/src/test/java/com/eum/post/service/impl/PostServiceImplTest.java
@@ -6,7 +6,6 @@ import com.eum.global.model.entity.Position;
 import com.eum.global.model.entity.TechStack;
 import com.eum.global.model.repository.PositionRepository;
 import com.eum.global.model.repository.TechStackRepository;
-import com.eum.member.model.entity.Member;
 import com.eum.post.model.dto.request.PostRequest;
 import com.eum.post.model.dto.response.PostResponse;
 import com.eum.post.model.entity.Post;
@@ -18,7 +17,6 @@ import com.eum.post.model.repository.PostPositionRepository;
 import com.eum.post.model.repository.PostRepository;
 import com.eum.post.model.repository.PostTechStackRepository;
 import com.eum.post.service.PortfolioService;
-import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,7 +35,6 @@ import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -71,14 +68,12 @@ public class PostServiceImplTest {
     private PostRequest testPostRequest;
     private Position testPosition;
     private TechStack testTechStack;
-    //private Long testUserId;
-    private UUID testUserId; //UUID로 변경
+    private Long testUserId;
 
     @BeforeEach
     void setUp() {
         // 테스트 데이터 초기화
-        //testUserId = 1L;
-        testUserId = UUID.fromString("5f8c7b9a-6e4d-4f8c-a1b2-3c4d5e6f7a8b");
+        testUserId = 1L;
 
         testPosition = Position.of("백엔드");
         testTechStack = TechStack.of("Java");
@@ -97,14 +92,7 @@ public class PostServiceImplTest {
                 Arrays.asList(1L)
         );
 
-        // Member 객체 Mock 생성
-        Member testMember = mock(Member.class);
-        when(testMember.getPublicId()).thenReturn(testUserId);
-
-        // 테스트 Post 엔티티 생성
-        testPost = testPostRequest.toEntity(testMember);
-
-        //testPost = testPostRequest.toEntity(testUserId); 기존 코드
+        testPost = testPostRequest.toEntity(testUserId);
         setPostId(testPost, 1L);
     }
 
@@ -122,7 +110,6 @@ public class PostServiceImplTest {
     @Test
     @DisplayName("게시글 생성 - 성공")
     void createPostSuccess() {
-
         // given
         given(postRepository.save(any(Post.class))).willReturn(testPost);
         given(techStackRepository.findById(1L)).willReturn(Optional.of(testTechStack));
@@ -244,10 +231,7 @@ public class PostServiceImplTest {
     @DisplayName("게시글 수정 - 권한 없음 실패")
     void updateNoPermissionFail() {
         Long postId = 1L;
-        //Long differentUserId = 999L;
-        //UUID로 변경
-        UUID differentUserId = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");  // 다른 UUID 사용
-
+        Long differentUserId = 999L;
 
         given(postRepository.findById(postId)).willReturn(Optional.of(testPost));
 
@@ -276,10 +260,7 @@ public class PostServiceImplTest {
     @DisplayName("게시글 삭제 - 권한 없음 실패")
     void deletePostNoPermissionFail() {
         Long postId = 1L;
-        //Long differentUserId = 999L;
-        //UUID로 변경
-        UUID differentUserId = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");  // 다른 UUID 사용
-
+        Long differentUserId = 999L;
 
         given(postRepository.findById(postId)).willReturn(Optional.of(testPost));
 
@@ -319,7 +300,7 @@ public class PostServiceImplTest {
         given(postPositionRepository.findByPostId(any())).willReturn(Arrays.asList());
 
         Page<PostResponse> responses = postService.findPostsWithFilters(
-                null, null, null, null, null, null, null, pageable
+                null, null, null, null, null, null, pageable
         );
 
         assertNotNull(responses);
@@ -340,7 +321,7 @@ public class PostServiceImplTest {
         given(postPositionRepository.findByPostId(any())).willReturn(Arrays.asList());
 
         Page<PostResponse> responses = postService.findPostsWithFilters(
-                keyword, null, null, null, null, null, null, pageable
+                keyword, null, null, null, null, null, pageable
         );
 
         assertNotNull(responses);

--- a/src/test/java/com/eum/post/service/impl/PostServiceImplTest.java
+++ b/src/test/java/com/eum/post/service/impl/PostServiceImplTest.java
@@ -6,6 +6,7 @@ import com.eum.global.model.entity.Position;
 import com.eum.global.model.entity.TechStack;
 import com.eum.global.model.repository.PositionRepository;
 import com.eum.global.model.repository.TechStackRepository;
+import com.eum.member.model.entity.Member;
 import com.eum.post.model.dto.request.PostRequest;
 import com.eum.post.model.dto.response.PostResponse;
 import com.eum.post.model.entity.Post;
@@ -17,6 +18,7 @@ import com.eum.post.model.repository.PostPositionRepository;
 import com.eum.post.model.repository.PostRepository;
 import com.eum.post.model.repository.PostTechStackRepository;
 import com.eum.post.service.PortfolioService;
+import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -35,6 +37,7 @@ import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -68,12 +71,14 @@ public class PostServiceImplTest {
     private PostRequest testPostRequest;
     private Position testPosition;
     private TechStack testTechStack;
-    private Long testUserId;
+    //private Long testUserId;
+    private UUID testUserId;
 
     @BeforeEach
     void setUp() {
         // 테스트 데이터 초기화
-        testUserId = 1L;
+        //testUserId = 1L;
+        testUserId = UUID.fromString("5f8c7b9a-6e4d-4f8c-a1b2-3c4d5e6f7a8b");
 
         testPosition = Position.of("백엔드");
         testTechStack = TechStack.of("Java");
@@ -92,8 +97,15 @@ public class PostServiceImplTest {
                 Arrays.asList(1L)
         );
 
-        testPost = testPostRequest.toEntity(testUserId);
+        // Member 객체 Mock 생성
+        Member testMember = mock(Member.class);
+        when(testMember.getPublicId()).thenReturn(testUserId);
+        // 테스트 Post 엔티티 생성
+        testPost = testPostRequest.toEntity(testMember);
         setPostId(testPost, 1L);
+
+//        testPost = testPostRequest.toEntity(testUserId);
+//        setPostId(testPost, 1L);
     }
 
     // 유틸리티 메서드
@@ -110,6 +122,7 @@ public class PostServiceImplTest {
     @Test
     @DisplayName("게시글 생성 - 성공")
     void createPostSuccess() {
+
         // given
         given(postRepository.save(any(Post.class))).willReturn(testPost);
         given(techStackRepository.findById(1L)).willReturn(Optional.of(testTechStack));
@@ -231,7 +244,9 @@ public class PostServiceImplTest {
     @DisplayName("게시글 수정 - 권한 없음 실패")
     void updateNoPermissionFail() {
         Long postId = 1L;
-        Long differentUserId = 999L;
+        //Long differentUserId = 999L;
+        UUID differentUserId = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");  // 다른 UUID 사용
+
 
         given(postRepository.findById(postId)).willReturn(Optional.of(testPost));
 
@@ -260,7 +275,9 @@ public class PostServiceImplTest {
     @DisplayName("게시글 삭제 - 권한 없음 실패")
     void deletePostNoPermissionFail() {
         Long postId = 1L;
-        Long differentUserId = 999L;
+        //Long differentUserId = 999L;
+        UUID differentUserId = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");  // 다른 UUID 사용
+
 
         given(postRepository.findById(postId)).willReturn(Optional.of(testPost));
 
@@ -300,7 +317,7 @@ public class PostServiceImplTest {
         given(postPositionRepository.findByPostId(any())).willReturn(Arrays.asList());
 
         Page<PostResponse> responses = postService.findPostsWithFilters(
-                null, null, null, null, null, null, pageable
+                null, null, null, null, null, null, null, pageable
         );
 
         assertNotNull(responses);
@@ -321,7 +338,7 @@ public class PostServiceImplTest {
         given(postPositionRepository.findByPostId(any())).willReturn(Arrays.asList());
 
         Page<PostResponse> responses = postService.findPostsWithFilters(
-                keyword, null, null, null, null, null, pageable
+                keyword, null, null, null, null, null, null, pageable
         );
 
         assertNotNull(responses);


### PR DESCRIPTION
## 관련 이슈

> #{ISSUE_NUMBER}

#56 

## 작업 내용
```java
@PostMapping("/{postId}/members")
    public ResponseEntity<List<PostMemberResponse>> updateMembers(
        @PathVariable Long postId,
        @RequestBody PostMemberRequest request,
        HttpServletRequest httpRequest
    )
    {
        UUID publicId = (UUID) httpRequest.getAttribute("publicId");

        return ResponseEntity.ok(
                postMemberService.updateMembers(postId, request.nicknames(), publicId)
                        .stream()
                        .map(PostMemberResponse::from)
                        .collect(Collectors.toList())
        );
    }
```
기존 코드는 response를 서비스레이어에서 직접 다뤘었는데
현재 컨트롤러, service 레이어에서 하나의 dto만 사용하도록 리펙토링

## ETC
> 참고할만한 링크 또는 메모

